### PR TITLE
fix parsing lldp split

### DIFF
--- a/ofp_fsfw_v10.py
+++ b/ofp_fsfw_v10.py
@@ -13,7 +13,9 @@ def support_fsfw(print_options, lldp):
 
     ip = print_options['device_ip']
     port = print_options['device_port']
-    dpid = lldp['c_id'].split(':')[1]
+    dpid = lldp['c_id']
+    if ':' in dpid:
+        dpid = dpid.split(':')[1]
 
     name = get_name_dpid(dpid)
     NET[ip, port] = name


### PR DESCRIPTION
Without this check, I was hitting on this exception,  since I was testing mininet and Kytos without running FlowSpace Firewall:

2017-08-17 16:30:48.909416 127.0.0.1:6633 -> 127.0.0.1:43556 Size: 126 Bytes
OpenFlow Version: 1.0(1) Type: PacketOut(13) Length: 60  XID: 3685050879
3685050879 PacketOut: buffer_id: 0xffffffff in_port: None(0xFFFF) actions_len: 8
3685050879 OpenFlow Action - Type: OUTPUT Length: 8 Port: 1 Max Length: 65535
3685050879 Ethernet: Destination MAC: 01:80:c2:00:00:0e Source MAC: 02:39:ba:7d:b0:9a Protocol: 0x88cc
**list index out of range**


