### PR TITLE
Fix python interpreter and syntax warnings

### DIFF
--- a/libs/core/cli.py
+++ b/libs/core/cli.py
@@ -62,7 +62,7 @@ def check_file_position(filename):
     """
     new_file = filename.partition(":")[0]
     position = filename.partition(":")[2]
-    return new_file, int(position) if len(position) is not 0 else 0
+    return new_file, int(position) if len(position) != 0 else 0
 
 
 def start_capture(capfile, infilter, dev):
@@ -91,7 +91,7 @@ def start_capture(capfile, infilter, dev):
         print("Exiting...")
         sys.exit(3)
 
-    if len(infilter) is 0:
+    if len(infilter) == 0:
         # Super specific filter to overcome the python-pcapy performance issue
         # reported on https://github.com/CoreSecurity/pcapy/issues/12
         # infilter = "tcp and port 6633 and (tcp[13] & 8!=0 or (tcp[13] & 1!=0 and tcp[13] & 16!=0))"

--- a/libs/core/save_to_file.py
+++ b/libs/core/save_to_file.py
@@ -14,7 +14,7 @@ def save_to_file(log_file):
     """
         Change default output to be SaveFile()
     """
-    if len(log_file) is not 0:
+    if len(log_file) != 0:
         sys.stdout = SaveFile(log_file)
 
 

--- a/libs/openflow/of10/prints.py
+++ b/libs/openflow/of10/prints.py
@@ -260,7 +260,7 @@ def print_data(data):
         elif next_protocol in [2048]:
             ip = data.pop(0)
             libs.tcpiplib.prints.print_layer3(ip)
-            if ip.protocol is 6:
+            if ip.protocol == 6:
                 tcp = data.pop(0)
                 libs.tcpiplib.prints.print_tcp(tcp)
         elif next_protocol in [2054]:
@@ -318,7 +318,7 @@ def print_ofpt_packet_out(msg):
           (hex(msg.buffer_id.value),
            green(dissector.get_phy_port_id(msg.in_port.value)),
            msg.actions_len.value))
-    if msg.actions_len is not 0:
+    if msg.actions_len != 0:
         print_actions(msg.actions)
         print_data(msg.data)
 
@@ -349,11 +349,11 @@ def print_ofp_match(match):
     for match_item in match.__dict__:
         match_item_value = match.__dict__[match_item]
         if match_item_value.value not in [0, "00:00:00:00:00:00", "0.0.0.0", 65535]:
-            if match_item is 'dl_vlan' and match_item_value.value not in [65535]:
+            if match_item == 'dl_vlan' and match_item_value.value not in [65535]:
                 match_item_value = dissector.get_vlan(match_item_value.value)
-            elif match_item is 'wildcards':
+            elif match_item == 'wildcards':
                 match_item_value = hex(match_item_value.value)
-            elif match_item is 'dl_type' and match_item_value.value not in [65535]:
+            elif match_item == 'dl_type' and match_item_value.value not in [65535]:
                 match_item_value = libs.tcpiplib.tcpip.get_ethertype(match_item_value.value)
             elif match_item in ['pad1', 'pad2']:
                 continue

--- a/libs/openflow/of13/prints.py
+++ b/libs/openflow/of13/prints.py
@@ -299,7 +299,7 @@ def print_data(data):
         elif next_protocol in [2048]:
             ip = data.pop(0)
             libs.tcpiplib.prints.print_layer3(ip)
-            if ip.protocol is 6:
+            if ip.protocol == 6:
                 tcp = data.pop(0)
                 libs.tcpiplib.prints.print_tcp(tcp)
         elif next_protocol in [2054]:
@@ -358,7 +358,7 @@ def print_ofpt_packet_out(msg):
           (hex(msg.buffer_id.value),
            green(dissector.get_phy_port_no(msg.in_port.value)),
            msg.actions_len.value))
-    if msg.actions_len is not 0:
+    if msg.actions_len != 0:
         print(" Actions:")
         for action in msg.actions:
             print("  ", end="")

--- a/libs/tcpiplib/packet.py
+++ b/libs/tcpiplib/packet.py
@@ -229,7 +229,7 @@ class LLDP:
         chassis_raw = packet[:3]
         chassis = unpack('!HB', chassis_raw)
         self.c_type = chassis[0] >> 9
-        if self.c_type is not 1:
+        if self.c_type != 1:
             return {}
 
         self.c_length = chassis[0] & 0xFF
@@ -257,7 +257,7 @@ class LLDP:
         port_raw = packet[start:start + 3]
         port = unpack('!HB', port_raw)
         self.p_type = port[0] >> 9
-        if self.p_type is not 2:
+        if self.p_type != 2:
             return {}
         self.p_length = port[0] & 0xFF
         self.p_subtype = port[1]
@@ -265,11 +265,11 @@ class LLDP:
         # Get P_ID
         port_raw = packet[start + 3:start + 3 + length]
         # string = '!%ss' % length
-        if length is 1:
+        if length == 1:
             string = '!B'
-        elif length is 2:
+        elif length == 2:
             string = '!H'
-        elif length is 4:
+        elif length == 4:
             string = '!L'
         else:
             string = '!%ss' % length
@@ -282,7 +282,7 @@ class LLDP:
         ttl_raw = packet[start:start + 4]
         ttl = unpack('!HH', ttl_raw)
         self.t_type = ttl[0] >> 9
-        if self.t_type is not 3:
+        if self.t_type != 3:
             return {}
         self.t_length = ttl[0] & 0xFF
         self.t_ttl = ttl[1]

--- a/libs/tcpiplib/prints.py
+++ b/libs/tcpiplib/prints.py
@@ -217,24 +217,24 @@ def print_lldp(lldp):
     Args:
         lldp: LLDP class
     """
-    if lldp.c_type is not 1 or lldp.p_type is not 2 \
-            or lldp.t_type is not 3 or lldp.e_type is not 0:
+    if lldp.c_type != 1 or lldp.p_type != 2 \
+            or lldp.t_type != 3 or lldp.e_type != 0:
         print('LLDP: Malformed packet')
         return
 
-    if lldp.c_type is 1:
+    if lldp.c_type == 1:
         if isinstance(lldp.c_id, bytes):
             lldp.c_id = lldp.c_id.decode("utf-8")
         print('LLDP: Chassis Type(%s) Length: %s SubType: %s ID: %s' %
               (lldp.c_type, lldp.c_length, lldp.c_subtype, green(datapath_id(lldp.c_id))))
-    if lldp.p_type is 2:
+    if lldp.p_type == 2:
         print('LLDP: Port Type(%s) Length: %s SubType: %s ID: %s' %
               (lldp.p_type, lldp.p_length, lldp.p_subtype, green(lldp.p_id)))
-    if lldp.t_type is 3:
+    if lldp.t_type == 3:
         print('LLDP: TTL(%s) Length: %s Seconds: %s' %
               (lldp.t_type, lldp.t_length, lldp.t_ttl))
 
-    if lldp.e_type is 0:
+    if lldp.e_type == 0:
         print('LLDP: END(%s) Length: %s' % (lldp.e_type, lldp.e_length))
 
 

--- a/libs/tcpiplib/process_data.py
+++ b/libs/tcpiplib/process_data.py
@@ -95,7 +95,7 @@ def dissect_data(data, start=0):
         ip_addr = IP()
         ip_addr.parse(packet, start)
         payload.append(ip_addr)
-        if ip_addr.protocol is 6:
+        if ip_addr.protocol == 6:
             tcp = TCP()
             tcp.parse(packet, start + ip_addr.length)
             payload.append(tcp)

--- a/ofp_sniffer.py
+++ b/ofp_sniffer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3
 
 """
     This code is the AmLight OpenFlow Sniffer
@@ -189,7 +189,7 @@ class RunSniffer(object):
                 # If a specific packet was selected, end here.
                 raise EndOfPcapFile
 
-        elif len(packet) is 0:
+        elif len(packet) == 0:
             return 3
 
         self.packet_count += 1


### PR DESCRIPTION
Fixes #23 
Fixes #24 

This PR changes ofp_sniffer to fix to simple issues:
- Using the python3 interpreter instead of python3.6
- Fix syntax warnings related to usage of `is` or `is not` with literals 